### PR TITLE
removed a unnecessary column in the meta report for succeeded test when ...

### DIFF
--- a/Modelica_ResultCompare/Report.cs
+++ b/Modelica_ResultCompare/Report.cs
@@ -450,7 +450,7 @@ namespace CsvCompare
                                     if (r.RelativePaths)
                                         writer.WriteLine("<tr><td colspan=\"2\" class=\"ok right\">SUCCEEDED</td><td class=\"ok\"><a href=\"{0}\">{0}</a></td></tr>", Path.GetFileName(r.FileName));
                                     else
-                                        writer.WriteLine("<tr><td colspan=\"2\" class=\"ok right\">SUCCEEDED</td><td class=\"ok\"><td class=\"ok\"><a href=\"file:///{0}\">{1}</a></td></tr>", r.FileName.Replace("\\", "/"), r.FileName);
+                                        writer.WriteLine("<tr><td colspan=\"2\" class=\"ok right\">SUCCEEDED</td><td class=\"ok\"><a href=\"file:///{0}\">{1}</a></td></tr>", r.FileName.Replace("\\", "/"), r.FileName);
                                 }
                             }
                             else


### PR DESCRIPTION
...using absolute paths.

Hi Sven, der Report Writer hat hier eine Spalte zu viel geschrieben.