### PR TITLE
incorrect if statement fixed

### DIFF
--- a/Modelica_ResultCompare/CsvFile.cs
+++ b/Modelica_ResultCompare/CsvFile.cs
@@ -124,10 +124,11 @@ namespace CsvCompare
 
                         //values = reg.Split(sLine); //splitting using regular expressions is slow
                         IEnumerable<string> dataValues;
-                        if (options.Delimiter.Equals(options.Separator))
-                            dataValues = Tokenize(sLine, options.Delimiter); //use custom tokenizer for improved performance
+                        if ( options.Delimiter.Equals( options.Separator ) )
+                            throw new ArgumentException( String.Format( CultureInfo.CurrentCulture, "The delimiter \"{0}\" and separator \"{1}\" are equal. This makes correct parsing impossible.",
+                                options.Delimiter, options.Separator ) );
                         else
-                            dataValues = sLine.Split(options.Delimiter); //use ordinary Split function for simple cases
+                            dataValues = Tokenize( sLine, options.Delimiter ); //use custom tokenizer for improved performance
                         
                         int iCol = 0;
 

--- a/Modelica_ResultCompare/CsvFile.cs
+++ b/Modelica_ResultCompare/CsvFile.cs
@@ -75,7 +75,7 @@ namespace CsvCompare
                     List<string> map = new List<string>();
 
                     //skip comments
-                    while (!string.IsNullOrEmpty(sLine) && sLine.StartsWith("#", StringComparison.OrdinalIgnoreCase))
+                    while ( string.IsNullOrEmpty( sLine ) || sLine.StartsWith( "#", StringComparison.OrdinalIgnoreCase ) )
                         sLine = reader.ReadLine();
 
                     Regex reg = new Regex(string.Format(CultureInfo.CurrentCulture, "{0}(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))", options.Delimiter));


### PR DESCRIPTION
fixed potential error with incorrect if statement. the tokenizer is now used for every line parsing process.

The original statement
```csharp
if (options.Delimiter.Equals(options.Separator))
    dataValues = Tokenize(sLine, options.Delimiter); //use custom tokenizer for improved performance
else
    dataValues = sLine.Split(options.Delimiter); //use ordinary Split function for simple cases
```

was always false since otherwise it would've been impossible to corretcly read the csv file. now it always uses the Tokenizer and throws an ArgumentException if delimiter and separator are equal.