### PR TITLE
ignore the msbuild.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 test/
 deliver/
+msbuild.log
 Modelica_ResultCompare/obj/
 Modelica_ResultCompare/bin/
 *.suo


### PR DESCRIPTION
This also makes it easier to use `git clean` for cleaning up.
https://git-scm.com/docs/git-clean