### PR TITLE
don't create temp logfile when logging to console

### DIFF
--- a/Modelica_ResultCompare/Log.cs
+++ b/Modelica_ResultCompare/Log.cs
@@ -126,15 +126,15 @@ namespace CsvCompare
                 Console.WriteLine("---------------");
             }
 
-            if (null == _logFileInfo)
-                _logFileInfo = new FileInfo(Path.GetTempFileName());
-
             _lastLog = string.Format(CultureInfo.CurrentCulture, "{0} [ {1,11} ] {2}",
                             timeStamp.ToString("yyyy-MM-ddZHH:mm:ss", CultureInfo.CurrentCulture),
                             level.ToString(), message);
 
             if (_logToFile)
             {
+                if (null == _logFileInfo)
+                    _logFileInfo = new FileInfo(Path.GetTempFileName());
+
                 using (TextWriter logFile = new StreamWriter(_logFileInfo.FullName, true, Encoding.UTF8))
                 {
 


### PR DESCRIPTION
Create the temp log only if we are going to use it. This prevents temp file leaks when logging to console.

This is a big problem for us in our CI system. There are large number of files created in temp-directory, which requires us to regularly run clean-up scripts.