### PR TITLE
Assemble the report file names from the compare directory structure

### DIFF
--- a/Modelica_ResultCompare/Modelica_ResultCompare.csproj
+++ b/Modelica_ResultCompare/Modelica_ResultCompare.csproj
@@ -262,6 +262,7 @@
     <Compile Include="Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Report.cs" />
+    <Compile Include="Util.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Modelica_ResultCompare/Options.cs
+++ b/Modelica_ResultCompare/Options.cs
@@ -36,7 +36,7 @@ namespace CsvCompare
         [Option('o', "override", DefaultValue = false, HelpText = "Override output files if they already exist (Default behaviour is to put the output next to the found file with a time stamp in the file name).")]
         public bool OverrideOutput { get; set; }
 
-        [Option('e', "abserror", DefaultValue = false, HelpText = "Shows, if set, only 0 and 1 in the error graph (peeks) instead of the difference between the error and the penetrated tube.")]
+        [Option('e', "abserror", DefaultValue = false, HelpText = "Shows, if set, only 0 and 1 in the error graph (peaks) instead of the difference between the error and the penetrated tube.")]
         public bool AbsoluteError { get; set; }
 
         [Option("comparisonflag", DefaultValue = false, HelpText = "Generates a text file that indicates if the test has been passed and contains test details.")]
@@ -48,7 +48,7 @@ namespace CsvCompare
         [Option('n', "nometareport", DefaultValue = false, HelpText = "Set this to disable the generation of a meta report.")]
         public bool NoMetaReport { get; set; }
 
-        [Option('b', "bitmap", DefaultValue = false, HelpText = "Set this to generate raster instead of vector plots (i.e. reports will shrink).")]
+        [Option('b', "bitmap", DefaultValue = false, HelpText = "Set this to generate raster instead of vector plots (i.e., reports will shrink).")]
         public bool UseBitmapPlots { get; set; }
 
         [Option('i', "inline", DefaultValue = false, HelpText = "If set, javascript and style sheet files are inserted as inline text in every html output file")]
@@ -63,8 +63,11 @@ namespace CsvCompare
         [Option('d', "delimiter", Required = false, HelpText = "Sets the delimiter that is used to parse and write csv files. Default value is \";\".")]
         public char Delimiter { get; set; }
 
-        [Option('s', "separator", DefaultValue = '.', Required = false, HelpText = "Sets the decimal separator that is used to parse and write csv files. Default value is \".\".")]
+        [Option('s', "separator", DefaultValue = '.', Required = false, HelpText = "Sets the decimal separator that is used to parse and write csv files [Default is \".\"].")]
         public char Separator { get; set; }
+
+        [Option('p', "reportnamesep", Required = false, DefaultValue = ".", HelpText = "Sets the namespace separator when assembling the report file names from the directory structure for CsvTreeCompare mode [Default is \".\"].")]
+        public string ReportNamespaceSeparator { get; set; }
 
         [ValueList(typeof(List<string>))]
         public IList<string> Items { get; set; }

--- a/Modelica_ResultCompare/Program.cs
+++ b/Modelica_ResultCompare/Program.cs
@@ -70,6 +70,12 @@ namespace CsvCompare
             }
         }
 
+        private static string GetFullPathWithEndingSlashes(string input)
+        {
+            string fullPath = Path.GetFullPath(input);
+            return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        }
+
         private static void Run(string[] cmdArgs)
         {
             var options = new Options();
@@ -126,15 +132,15 @@ namespace CsvCompare
                     FileAttributes attr = File.GetAttributes(options.Items[0]);
 
                     if ((attr & FileAttributes.Directory) == FileAttributes.Directory)
-                        options.ReportDir = Path.GetFullPath(options.Items[0]);
+                        options.ReportDir = GetFullPathWithEndingSlashes(options.Items[0]);
                     else
-                        options.ReportDir = Path.GetDirectoryName(options.Items[0]);
+                        options.ReportDir = GetFullPathWithEndingSlashes(Path.GetDirectoryName(options.Items[0]));
                     _log.WriteLine(LogLevel.Warning, "No report directory has been set, using \"{0}\"", options.ReportDir);
                 }
                 else
                 {
                     meta.ReportDirSet = true;
-                    options.ReportDir = Path.GetFullPath(options.ReportDir);//normalize report dir (i.e. make absolut if relative)
+                    options.ReportDir = GetFullPathWithEndingSlashes(options.ReportDir);//normalize report dir (i.e. make absolut if relative)
                     if (!Directory.Exists(options.ReportDir))
                         Directory.CreateDirectory(options.ReportDir);
                 }
@@ -164,6 +170,8 @@ namespace CsvCompare
                             Console.WriteLine(options.GetUsage());
                             Environment.Exit(2);
                         }
+                        options.Items[0] = GetFullPathWithEndingSlashes(options.Items[0]);
+                        options.Items[1] = GetFullPathWithEndingSlashes(options.Items[1]);
                         CheckTrees(meta, options);
                         if(!options.NoMetaReport)
                             meta.WriteReport(_log, options);

--- a/Modelica_ResultCompare/Report.cs
+++ b/Modelica_ResultCompare/Report.cs
@@ -690,7 +690,7 @@ namespace CsvCompare
                 _metaPath = string.Empty;
 
             if (!string.IsNullOrEmpty(options.ReportDir))
-                _path = Path.Combine(options.ReportDir, Path.GetFileName(_path));
+                _path = Path.Combine(options.ReportDir, Util.GetTrailingPath(Path.GetDirectoryName(options.Items[0]), _path, options.ReportNamespaceSeparator));
             else
             {
                 try

--- a/Modelica_ResultCompare/Util.cs
+++ b/Modelica_ResultCompare/Util.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+
+namespace CsvCompare
+{
+    public static class Util
+    {
+        public static string GetTrailingPath(string relTo, string absPath, string sep)
+        {
+            string[] absDirs = absPath.Split(Path.DirectorySeparatorChar);
+            string[] relDirs = relTo.Split(Path.DirectorySeparatorChar);
+            int len = absDirs.Length < relDirs.Length ? absDirs.Length : relDirs.Length;
+            // Use to determine where in the loop we exited
+            int lastCommonRoot = -1; int index;
+            // Find common root
+            for (index = 0; index < len; index++)
+            {
+                if (absDirs[index] == relDirs[index])
+                    lastCommonRoot = index;
+                else
+                    break;
+            }
+            // If we didn't find a common prefix then throw
+            if (lastCommonRoot == -1)
+            {
+                throw new ArgumentException("Paths do not have a common base");
+            }
+            // Build up the trailing path
+            string path = string.Join(sep, absDirs, lastCommonRoot + 1, absDirs.Length - lastCommonRoot - 1);
+            return path;
+        }
+    }
+}


### PR DESCRIPTION
* Only relevant for operation mode CsvTreeCompare
* Name space separator can be specified on command line as new argument
* Directory separator character as name space separator is not supported, that is the generated reports are still a flat list