### PR TITLE
Force a unique bitmap name

### DIFF
--- a/Modelica_ResultCompare/Report.cs
+++ b/Modelica_ResultCompare/Report.cs
@@ -213,7 +213,7 @@ namespace CsvCompare
         {
             path = Path.GetDirectoryName(path);
 
-            string Filename = string.Format("{0}.png", this.Title);
+            string Filename = string.Format("{0}-{1}.png", this.Title, this.Id.ToString());
             string ImagePath = Path.Combine(path, @"img", Filename);
 
             StringBuilder sb;


### PR DESCRIPTION
If (for csvTreeCompare) a directory structure contains the same CSV file names, the generated bitmaps are shared.

Example: [Modelica.Fluid.Examples.ControlledTankSystem.ControlledTanks](http://www.ltx.de/download/MA/Compare_MSL_v3.2.3-rc.2/2018-12-15_230315_Modelica_v3.2.3-rc.2_2019/compare/Fluid.Examples.ControlledTankSystem.ControlledTanks.ControlledTanks_report.html) and [Modelica.StateGraph.Examples.ControlledTanks](http://www.ltx.de/download/MA/Compare_MSL_v3.2.3-rc.2/2018-12-15_230315_Modelica_v3.2.3-rc.2_2019/compare/StateGraph.Examples.ControlledTanks.ControlledTanks_report.html) share the same PNG image  [ControlledTanks.tank1.level.png](http://www.ltx.de/download/MA/Compare_MSL_v3.2.3-rc.2/2018-12-15_230315_Modelica_v3.2.3-rc.2_2019/compare/img/ControlledTanks.tank1.level.png).

This fix forces unique PNG file names, at the cost that a new compare run (with option --override set) does not override the existing PNG images.

@svenruetz Is this acceptable?
@GallLeo FYI