### PR TITLE
Add option to only plot failed tests in the report

### DIFF
--- a/Modelica_ResultCompare/Options.cs
+++ b/Modelica_ResultCompare/Options.cs
@@ -69,6 +69,9 @@ namespace CsvCompare
         [Option('p', "reportnamesep", Required = false, DefaultValue = ".", HelpText = "Sets the namespace separator when assembling the report file names from the directory structure for CsvTreeCompare mode [Default is \".\"].")]
         public string ReportNamespaceSeparator { get; set; }
 
+        [Option('f', "failedonly", Required = false, DefaultValue = false, HelpText = "Set this to only plot failed tests in the reports (i.e., reports will shrink).")]
+        public bool FailedOnly { get; set; }
+
         [ValueList(typeof(List<string>))]
         public IList<string> Items { get; set; }
 

--- a/Modelica_ResultCompare/Report.cs
+++ b/Modelica_ResultCompare/Report.cs
@@ -730,7 +730,7 @@ namespace CsvCompare
             using (TextWriter writer = new StreamWriter(_path, false))
             {
                 WriteHeader(writer, options);
-                WriteChart(writer);
+                WriteChart(writer, options);
                 WriteFooter(writer);
                 bRet = true;
             }
@@ -783,13 +783,17 @@ namespace CsvCompare
 ");
         }
 
-        private void WriteChart(TextWriter writer)
+        private void WriteChart(TextWriter writer, Options options)
         {
             foreach (Chart ch in _chart)
+            {
+                if (options.FailedOnly && ch.Errors == 0)
+                    continue;
                 if (!ch.UseBitmap)
                     writer.WriteLine(ch.RenderChart());
                 else
                     writer.WriteLine(ch.RenderBitmap(this._path));
+            }
         }
 
         private void WriteHeader(TextWriter writer, Options options)


### PR DESCRIPTION
I have seen report files of size of several hundred MB which are almost impossible to load in browser or upload to GitHub.