### PR TITLE
Fix regression with inline option

### DIFF
--- a/Modelica_ResultCompare/Modelica_ResultCompare.csproj
+++ b/Modelica_ResultCompare/Modelica_ResultCompare.csproj
@@ -317,21 +317,13 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Resources\jquery.min.js" />
+    <EmbeddedResource Include="Resources\jquery.jqplot.min.js" />
+    <EmbeddedResource Include="Resources\jqplot.cursor.min.js" />
+    <EmbeddedResource Include="Resources\jqplot.canvasTextRenderer.min.js" />
+    <EmbeddedResource Include="Resources\jqplot.canvasAxisLabelRenderer.min.js" />
     <EmbeddedResource Include="Resources\excanvas.min.js" />
     <EmbeddedResource Include="Resources\jquery.jqplot.min.css" />
-    <EmbeddedResource Include="Resources\jquery.jqplot.min.js" />
-    <EmbeddedResource Include="Resources\jquery.min.js" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\jqplot.cursor.min.js" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\jqplot.canvasAxisLabelRenderer.min.js" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\jqplot.canvasTextRenderer.min.js" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Resources\style.css" />
   </ItemGroup>
 </Project>

--- a/Modelica_ResultCompare/Report.cs
+++ b/Modelica_ResultCompare/Report.cs
@@ -803,41 +803,36 @@ namespace CsvCompare
             writer.WriteLine("<title>Report {0}</title>", DateTime.Now);
 
             Assembly ass = Assembly.GetExecutingAssembly();
-            List<string> lScripts = new List<string>();
+            List<string> jScripts = new List<string>();
+            List<string> styleSheets = new List<string>();
             foreach (string s in ass.GetManifestResourceNames())
             {
-                if (!s.ToLowerInvariant().EndsWith(".js"))
-                    continue;
-                if (options.InlineScripts)
+                if (s.ToLowerInvariant().EndsWith(".js"))
                 {
-                    var javascriptHeaders = new StreamReader(ass.GetManifestResourceStream(s));
-                    lScripts.Add(string.Format("<script language=\"javascript\" type=\"text/javascript\">{0}</script>", javascriptHeaders.ReadToEnd()));
+                    if (options.InlineScripts)
+                    {
+                        var javascriptHeaders = new StreamReader(ass.GetManifestResourceStream(s));
+                        jScripts.Add(string.Format("<script language=\"javascript\" type=\"text/javascript\">{0}</script>", javascriptHeaders.ReadToEnd()));
+                    }
+                    else
+                        jScripts.Add(string.Format("<script src=\"js/{0}\"></script>", s));
                 }
-                else
-                    lScripts.Add(string.Format("<script src=\"js/{0}\"></script>", s));
+                else if (s.ToLowerInvariant().EndsWith(".css"))
+                {
+                    if (options.InlineScripts)
+                    {
+                        var stylesheetHeaders = new StreamReader(ass.GetManifestResourceStream(s));
+                        styleSheets.Add(string.Format("<style type=\"text/css\">{0}</style>", stylesheetHeaders.ReadToEnd()));
+                    }
+                    else
+                        styleSheets.Add(string.Format("<link rel=\"stylesheet\" type=\"text/css\" href=\"css/{0}\">", s));
+                }
             }
-            lScripts = lScripts.OrderByDescending(x => x).ToList<string>();//Sort alphabetically to ensure jquery is loaded first
-            writer.WriteLine(string.Join(Environment.NewLine, lScripts.ToArray()));
-            if (options.InlineScripts)
-            {
-                writer.WriteLine("<style type=\"text/css\">");
-                writer.WriteLine(".jqplot-target{position:relative;color:#666;font-family:\"Trebuchet MS\",Arial,Helvetica,sans-serif;font-size:1em;}.jqplot-axis{font-size:.75em;}.jqplot-xaxis{margin-top:10px;}.jqplot-x2axis{margin-bottom:10px;}.jqplot-yaxis{margin-right:10px;}.jqplot-y2axis,.jqplot-y3axis,.jqplot-y4axis,.jqplot-y5axis,.jqplot-y6axis,.jqplot-y7axis,.jqplot-y8axis,.jqplot-y9axis{margin-left:10px;margin-right:10px;}.jqplot-axis-tick,.jqplot-xaxis-tick,.jqplot-yaxis-tick,.jqplot-x2axis-tick,.jqplot-y2axis-tick,.jqplot-y3axis-tick,.jqplot-y4axis-tick,.jqplot-y5axis-tick,.jqplot-y6axis-tick,.jqplot-y7axis-tick,.jqplot-y8axis-tick,.jqplot-y9axis-tick{position:absolute;}.jqplot-xaxis-tick{top:0;left:15px;vertical-align:top;}.jqplot-x2axis-tick{bottom:0;left:15px;vertical-align:bottom;}.jqplot-yaxis-tick{right:0;top:15px;text-align:right;}.jqplot-yaxis-tick.jqplot-breakTick{right:-20px;margin-right:0;padding:1px 5px 1px 5px;z-index:2;font-size:1.5em;}.jqplot-y2axis-tick,.jqplot-y3axis-tick,.jqplot-y4axis-tick,.jqplot-y5axis-tick,.jqplot-y6axis-tick,.jqplot-y7axis-tick,.jqplot-y8axis-tick,.jqplot-y9axis-tick{left:0;top:15px;text-align:left;}.jqplot-meterGauge-tick{font-size:.75em;color:#999;}.jqplot-meterGauge-label{font-size:1em;color:#999;}.jqplot-xaxis-label{margin-top:10px;font-size:11pt;position:absolute;}.jqplot-x2axis-label{margin-bottom:10px;font-size:11pt;position:absolute;}.jqplot-yaxis-label{margin-right:10px;font-size:11pt;position:absolute;}.jqplot-y2axis-label,.jqplot-y3axis-label,.jqplot-y4axis-label,.jqplot-y5axis-label,.jqplot-y6axis-label,.jqplot-y7axis-label,.jqplot-y8axis-label,.jqplot-y9axis-label{font-size:11pt;position:absolute;}table.jqplot-table-legend{margin-top:12px;margin-bottom:12px;margin-left:12px;margin-right:12px;}table.jqplot-table-legend,table.jqplot-cursor-legend{background-color:rgba(255,255,255,0.6);border:1px solid #ccc;position:absolute;font-size:.75em;}td.jqplot-table-legend{vertical-align:middle;}td.jqplot-seriesToggle:hover,td.jqplot-seriesToggle:active{cursor:pointer;}td.jqplot-table-legend>div{border:1px solid #ccc;padding:1px;}div.jqplot-table-legend-swatch{width:0;height:0;border-top-width:5px;border-bottom-width:5px;border-left-width:6px;border-right-width:6px;border-top-style:solid;border-bottom-style:solid;border-left-style:solid;border-right-style:solid;}.jqplot-title{top:0;left:0;padding-bottom:.5em;font-size:1.2em;}table.jqplot-cursor-tooltip{border:1px solid #ccc;font-size:.75em;}.jqplot-cursor-tooltip{border:1px solid #ccc;font-size:.75em;white-space:nowrap;background:rgba(208,208,208,0.5);padding:1px;}.jqplot-highlighter-tooltip{border:1px solid #ccc;font-size:.75em;white-space:nowrap;background:rgba(208,208,208,0.5);padding:1px;}.jqplot-point-label{font-size:.75em;z-index:2;}td.jqplot-cursor-legend-swatch{vertical-align:middle;text-align:center;}div.jqplot-cursor-legend-swatch{width:1.2em;height:.7em;}.jqplot-error{text-align:center;}.jqplot-error-message{position:relative;top:46%;display:inline-block;}div.jqplot-bubble-label{font-size:.8em;padding-left:2px;padding-right:2px;color:rgb(20%,20%,20%);}div.jqplot-bubble-label.jqplot-bubble-label-highlight{background:rgba(90%,90%,90%,0.7);}div.jqplot-noData-container{text-align:center;background-color:rgba(96%,96%,96%,0.3);}");
-                writer.WriteLine("body{ background: #EEEEEE; color: #000; text-align: center;}");
-                writer.WriteLine("body, table{ font-family: Arial, Helvetica, sans-serif; font-size: 12px; }");
-                writer.WriteLine("#page{ width: 700px; margin: auto; text-align: left; background-color: #FFF;}");
-                writer.WriteLine("table.info{ border: 0; width: 690px; margin: 5px;}");
-                writer.WriteLine("table.info td{ background-color: #efefef; padding: 1em;}");
-                writer.WriteLine("table.info td.header{ font-weight: bold; width: 150px; background-color: #EEE;}");
-                writer.WriteLine("tr.error td, tr.error td.header { background-color: #F5A9BC; color: red; }");
-                writer.WriteLine("tr.warning td, tr.warning td.header { background-color: #FFCC66; color: #FF6600; }");
-                writer.WriteLine("h1{ font-size: 16px; padding: 1em; }");
-                writer.WriteLine("</style>");
-            }
-            else
-            {
-                writer.WriteLine("<link rel=\"stylesheet\" type=\"text/css\" href=\"css/CsvCompare.Resources.jquery.jqplot.min.css\">");
-                writer.WriteLine("<link rel=\"stylesheet\" type=\"text/css\" href=\"css/CsvCompare.Resources.style.css\">");
-            }
+            // jquery needs to be loaded first, this is guaranteed by the order of the resource files in the project configuration
+            foreach (string line in jScripts)
+                writer.WriteLine(line);
+            foreach (string line in styleSheets)
+                writer.WriteLine(line);
             writer.WriteLine("</head>");
             writer.WriteLine("<body>");
             writer.WriteLine("<div id=\"page\">");

--- a/Modelica_ResultCompare/Resources/style.css
+++ b/Modelica_ResultCompare/Resources/style.css
@@ -1,41 +1,9 @@
-body{
-	background: #EEEEEE;
-	color: #000;
-	text-align: center;
-}
-body, table{
-	font-family: Arial, Helvetica, sans-serif;
-	font-size: 12px; 
-}
-#page{ 
-	width: 700px; 
-	margin: auto; 
-	text-align: left; 
-	background-color: #FFF;
-}
-table.info{ 
-	border: 0; 
-	width: 690px; 
-	margin: 5px;
-}
-table.info td{ 
-	background-color: #efefef; 
-	padding: 1em;
-}
-table.info td.header{ 
-	font-weight: bold; 
-	width: 150px; 
-	background-color: #EEE;
-}
-tr.error td, tr.error td.header { 
-	background-color: #F5A9BC; 
-	color: red; 
-}
-tr.warning td, tr.warning td.header { 
-	background-color: #FFCC66; 
-	color: #FF6600; 
-}
-h1{ 
-	font-size: 16px; 
-	padding: 1em; 
-}
+body{ background: #EEEEEE; color: #000; text-align: center;}
+body, table{ font-family: Arial, Helvetica, sans-serif; font-size: 12px;}
+#page{ width: 700px; margin: auto; text-align: left; background-color: #FFF;}
+table.info{ border: 0; width: 690px; margin: 5px;}
+table.info td{ background-color: #efefef; padding: 1em;}
+table.info td.header{ font-weight: bold; width: 150px; background-color: #EEE;}
+tr.error td, tr.error td.header { background-color: #F5A9BC; color: red;}
+tr.warning td, tr.warning td.header { background-color: #FFCC66; color: #FF6600;}
+h1{ font-size: 16px; padding: 1em;}


### PR DESCRIPTION
* In #50, jquery.jqplot.min.css was updated, but this content was not considered for the inline option.
* The CSS files are always loaded from the resource files, just as the JS files. This avoids potential errors when updating jqplot in the future again.
* The resource files are sorted in the configuration the way they are required, i.e., jquery needs to be first in the list. This avoids sorting at run-time.