### PR TITLE
Use current directory as report directory if only file name is passed

### DIFF
--- a/Modelica_ResultCompare/Program.cs
+++ b/Modelica_ResultCompare/Program.cs
@@ -72,7 +72,15 @@ namespace CsvCompare
 
         private static string GetFullPathWithEndingSlashes(string input)
         {
-            string fullPath = Path.GetFullPath(input);
+            string fullPath;
+            if (string.IsNullOrEmpty(input))
+            {
+                fullPath = Directory.GetCurrentDirectory();
+            }
+            else
+            {
+                fullPath = Path.GetFullPath(input);
+            }
             return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
         }
 


### PR DESCRIPTION
If no report directory is specified and the specified CSV file (under comparison) only is a file name (without any directory separator), the use the current directory as report directory.

Resolves #56.