### PR TITLE
Avoid values of baseY less than 0.001

### DIFF
--- a/Modelica_ResultCompare/CsvFile.cs
+++ b/Modelica_ResultCompare/CsvFile.cs
@@ -313,7 +313,12 @@ namespace CsvCompare
                     else
                         log.WriteLine(LogLevel.Debug, "The resolution of the base x-axis is good.");
 
-                    size = new TubeSize(reference, true);
+                    // The actual nominal attribute should be used, but is unfortunately unavailable in the CSV files.
+                    // A default nominal value of 0.001 was chosen as a compromise between having many false negatives
+                    // and passing wrong result files.
+                    const double defaultNominalValue = 0.001;
+                    const bool useLegacyBaseAndRatio = true;
+                    size = new TubeSize(reference, defaultNominalValue, useLegacyBaseAndRatio);
                     size.Calculate(_dRangeDelta, Axes.X, Relativity.Relative);
                     tube = new Tube(size);
                     tubeReport = tube.Calculate(reference);

--- a/Modelica_ResultCompare/CurveCompare/TubeSize.cs
+++ b/Modelica_ResultCompare/CurveCompare/TubeSize.cs
@@ -70,44 +70,28 @@ namespace CurveCompare
             set { successful = value; }
         }
         /// <summary>
-        /// Creates an instanz of TubeSize. <para>
-        /// Base and Ratio get standard values.</para>
+        /// Creates an instance of TubeSize.
         /// </summary>
         /// <param name="reference">Reference curve.</param>
-        public TubeSize(Curve reference)
-        {
-            this.reference = reference;
-            SetStandardBaseAndRatio();
-            successful = false;
-        }
-        /// <summary>
-        /// Creates an instanz of TubeSize. <para>
-        /// Ratio and Base get standard values.</para>
-        /// </summary>
-        /// <param name="reference">Reference curve.</param>
-        /// <param name="formerBaseAndRatio">Base and Ratio are calculated like in the former CSV-Compare, if true;<para>
-        /// Ratio and Base get standard values, elsewise.</para></param>
-        public TubeSize(Curve reference, bool formerBaseAndRatio)
+        /// <param name="nominalValue">A nominal value handles the case of reference variables that are near-zero
+        /// e.g. because of being the result of balance equations affected by small numerical errors, but are meant
+        /// to have a much larger order of magnitude.</param>
+        /// <param name="formerBaseAndRatio">Base and Ratio are calculated like in the former CSV-Compare, if true;<param>
+        public TubeSize(Curve reference, double nominalValue, bool formerBaseAndRatio)
         {
             this.reference = reference;
             if (formerBaseAndRatio)
-                SetFormerBaseAndRatio();
+                SetFormerBaseAndRatio(nominalValue);
             else
-                SetStandardBaseAndRatio();
+                SetStandardBaseAndRatio(nominalValue);
             successful = false;
         }
         /// <summary>
         /// Calculates standard values for BaseX , BaseY and Ratio.
         /// </summary>
-        public void SetStandardBaseAndRatio()
+        /// <param name="nominalValue">Nominal value (required: greater than zero).</param>
+        private void SetStandardBaseAndRatio(double nominalValue)
         {
-            double default_nominal = 0.001;
-            // default_nominal provides a default nominal value to handle the case of reference variables that are near-zero
-            // e.g. because of being the result of balance equations affected by small numerical errors, but are meant
-            // to have a much larger order of magnitude. The nominal attribute should be used, but is unfortunately unavailable
-            // in the CSV files. A default nominal value of 0.001 was chosen as a compromise between having many false negatives
-            // and passing wrong result files
-
             // set baseX
             baseX = reference.X.Max() - reference.X.Min(); //reference.X.Max() - reference.X.Min() + Math.Abs(reference.X.Min());
             if (baseX == 0) // nonsense case, no data
@@ -115,7 +99,7 @@ namespace CurveCompare
             if (baseX == 0) // nonsense case, no data
                 baseX = 1;
             // set baseY
-            baseY = Math.Max(reference.Y.Max() - reference.Y.Min(), default_nominal);
+            baseY = Math.Max(reference.Y.Max() - reference.Y.Min(), nominalValue);
             // set ratio
             if (baseX != 0)
                 ratio = baseY / baseX;
@@ -125,19 +109,14 @@ namespace CurveCompare
         /// <summary>
         /// Calculates former standard values for BaseX , BaseY and Ratio.
         /// </summary>
-        public void SetFormerBaseAndRatio()
+        /// <param name="nominalValue">Nominal value (required: greater than zero).</param>
+        private void SetFormerBaseAndRatio(double nominalValue)
         {
-            double epsilon = 1e-12;
-            double default_nominal = 0.001;
-            // epsilon guards agains the case of result files with only on time point, for which baseX would be zero
+            // guard against the case with only one time point, for which baseX would be zero
+            const double epsilon = 1e-12;
             baseX = Math.Max(Math.Max(reference.X.Max() - reference.X.Min(), Math.Abs(reference.X.Min())), epsilon);
-            // default_nominal provides a default nominal value to handle the case of reference variables that are near-zero
-            // e.g. because of being the result of balance equations affected by small numerical errors, but are meant
-            // to have a much larger order of magnitude. The nominal attribute should be used, but is unfortunately unavailable
-            // in the CSV files. A default nominal value of 0.001 was chosen as a compromise between having many false negatives
-            // and passing wrong result files
-            baseY = Math.Max(Math.Max(reference.Y.Max() - reference.Y.Min(), Math.Abs(reference.Y.Min())), default_nominal);
-            ratio = baseY/baseX;
+            baseY = Math.Max(Math.Max(reference.Y.Max() - reference.Y.Min(), Math.Abs(reference.Y.Min())), nominalValue);
+            ratio = baseY / baseX;
             return;
         }
         /// <summary>

--- a/Modelica_ResultCompare/CurveCompare/TubeSize.cs
+++ b/Modelica_ResultCompare/CurveCompare/TubeSize.cs
@@ -101,6 +101,13 @@ namespace CurveCompare
         /// </summary>
         public void SetStandardBaseAndRatio()
         {
+            double default_nominal = 0.001;
+            // default_nominal provides a default nominal value to handle the case of reference variables that are near-zero
+            // e.g. because of being the result of balance equations affected by small numerical errors, but are meant
+            // to have a much larger order of magnitude. The nominal attribute should be used, but is unfortunately unavailable
+            // in the CSV files. A default nominal value of 0.001 was chosen as a compromise between having many false negatives
+            // and passing wrong result files
+
             // set baseX
             baseX = reference.X.Max() - reference.X.Min(); //reference.X.Max() - reference.X.Min() + Math.Abs(reference.X.Min());
             if (baseX == 0) // nonsense case, no data
@@ -108,11 +115,7 @@ namespace CurveCompare
             if (baseX == 0) // nonsense case, no data
                 baseX = 1;
             // set baseY
-            baseY = reference.Y.Max() - reference.Y.Min();
-            if (baseY == 0) // rare special case
-                baseY = Math.Abs(reference.Y.Max());
-            if (baseY == 0) // rare special case
-                baseY = 0.00000000000000001;
+            baseY = Math.Max(reference.Y.Max() - reference.Y.Min(), default_nominal);
             // set ratio
             if (baseX != 0)
                 ratio = baseY / baseX;
@@ -125,9 +128,16 @@ namespace CurveCompare
         public void SetFormerBaseAndRatio()
         {
             double epsilon = 1e-12;
+            double default_nominal = 0.001;
+            // epsilon guards agains the case of result files with only on time point, for which baseX would be zero
             baseX = Math.Max(Math.Max(reference.X.Max() - reference.X.Min(), Math.Abs(reference.X.Min())), epsilon);
-            ratio = Math.Max(Math.Max(reference.Y.Max() - reference.Y.Min(), Math.Abs(reference.Y.Min())), epsilon) / baseX;
-            baseY = baseX * ratio;
+            // default_nominal provides a default nominal value to handle the case of reference variables that are near-zero
+            // e.g. because of being the result of balance equations affected by small numerical errors, but are meant
+            // to have a much larger order of magnitude. The nominal attribute should be used, but is unfortunately unavailable
+            // in the CSV files. A default nominal value of 0.001 was chosen as a compromise between having many false negatives
+            // and passing wrong result files
+            baseY = Math.Max(Math.Max(reference.Y.Max() - reference.Y.Min(), Math.Abs(reference.Y.Min())), default_nominal);
+            ratio = baseY/baseX;
             return;
         }
         /// <summary>


### PR DESCRIPTION
This change considers a minimum range of Y reference values of 0.001, to avoid false negatives when handling near-zero values that are the result of balance equations affected by small numerical errors. 0.001 is a reasonable compromise, since the nominal attribute (which would be better) is not available in CSV result files.