### PR TITLE
Improve license visibility at GitHub

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -26,34 +26,3 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
-
-<http://opensource.org/licenses/BSD-3-Clause>
-
-* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
-The Result Compare uses the Commandline Parser
-<https://github.com/commandlineparser/commandline> that has been published under the MIT
-License:
-
-The MIT License (MIT)
-
-Copyright (c) 2005-2015 Giacomo Stelluti Scala & Contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to permit
-persons to whom the Software is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.

--- a/Third-party/LICENSE_NPlot.txt
+++ b/Third-party/LICENSE_NPlot.txt
@@ -1,0 +1,23 @@
+NPlot - A charting library for .NET
+Copyright (C) 2003-2006 Matt Howlett and others.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Third-party/LICENSE_commandline.txt
+++ b/Third-party/LICENSE_commandline.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2005 - 2015 Giacomo Stelluti Scala & Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Third-party/LICENSE_jquery.jqplot.txt
+++ b/Third-party/LICENSE_jquery.jqplot.txt
@@ -1,0 +1,21 @@
+Title: MIT License
+
+Copyright (c) 2009-2013 Chris Leonello
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,7 @@ then
         echo file version set to $fileversion
         sed -i 's/\(AssemblyInformationalVersionAttribute\)(.*/\1("'$version'")]/' $output
         echo informational version set to $version
-        sed -i 's/\(AssemblyCopyright\).*/AssemblyCopyright("Copyright © '$dt' ESI ITI GmbH")]/' $output
+        sed -i 's/\(AssemblyCopyright\).*/AssemblyCopyright("Copyright © '$dt' ESI ITI GmbH and contributors")]/' $output
 else
         echo "No template found @"$input!
         exit 1
@@ -31,15 +31,15 @@ then
 	cmd //c "winbuild.bat"
 	# create zip file
 	zipper="/c/Program Files/7-Zip/7z.exe"
-	"$zipper" a -tzip $root/csv-compare.windows-$version.x64.zip ./Modelica_ResultCompare/bin/x64/Release/Compare.exe BUILD.md LICENSE README.md RELEASENOTES.md
+	"$zipper" a -tzip $root/csv-compare.windows-$version.x64.zip ./Modelica_ResultCompare/bin/x64/Release/Compare.exe BUILD.md LICENSE README.md RELEASENOTES.md ./Third-party
 	echo "Successfully created the file $root/csv-compare.windows-$version.x64.tar.gz"
-	"$zipper" a -tzip $root/csv-compare.windows-$version.x86.zip  ./Modelica_ResultCompare/bin/x86/Release/Compare.exe BUILD.md LICENSE README.md RELEASENOTES.md
+	"$zipper" a -tzip $root/csv-compare.windows-$version.x86.zip  ./Modelica_ResultCompare/bin/x86/Release/Compare.exe BUILD.md LICENSE README.md RELEASENOTES.md ./Third-party
 	echo "Successfully created the file $root/csv-compare.windows-$version.x86.tar.gz"
 else
 	# build release
 	make release
 	# create zip file
-	tar -czf $root/csv-compare.linux-$version.tar.gz Modelica_ResultCompare/bin/Release/Compare.exe BUILD.md LICENSE README.md RELEASENOTES.md
+	tar -czf $root/csv-compare.linux-$version.tar.gz Modelica_ResultCompare/bin/Release/Compare.exe BUILD.md LICENSE README.md RELEASENOTES.md ./Third-party
 	echo "Successfully created the file csv-compare.linux-$version.tar.gz with the following content:"
 	tar tf $root/csv-compare.linux-$version.tar.gz
 fi


### PR DESCRIPTION
* Use a standard license text for the LICENSE at repository root
* Make licenses of used third-party components explicit

FYI @casella